### PR TITLE
check for returned localized string before replacing

### DIFF
--- a/eionet/theme/browser/overrides.py
+++ b/eionet/theme/browser/overrides.py
@@ -45,7 +45,9 @@ def patched_toLocalizedTime(self, time, long_format=None, time_only=None):
     loc_time = util.ulocalized_time(time, long_format, time_only,
                                     context=context, domain='plonelocales',
                                     request=self.request)
-    loc_time = loc_time.replace(',', '')
+    if loc_time:
+        loc_time = loc_time.replace(',', '')
+
     return loc_time
 
 


### PR DESCRIPTION
The original toLocalizedTime returns nothing when the entered parameter is an empty string or an invalid non-datetime parameter:

```
>>> toLocalizedTime('')
None
>>> toLocalizedTime('(Never)')
None
>>> toLocalizedTime(None)
'Jul 22, 2021'
```

But with this patch this behavior is modified, because it tries to replace the `,` anyway:

```
>>> ploneview.toLocalizedTime('')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/erral/downloads/eggs/eionet.theme-1.9-py3.7.egg/eionet/theme/browser/overrides.py", line 48, in patched_toLocalizedTime
    loc_time = loc_time.replace(',', '')
AttributeError: 'NoneType' object has no attribute 'replace'
>>> ploneview.toLocalizedTime('(Never)')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/erral/downloads/eggs/eionet.theme-1.9-py3.7.egg/eionet/theme/browser/overrides.py", line 48, in patched_toLocalizedTime
    loc_time = loc_time.replace(',', '')
AttributeError: 'NoneType' object has no attribute 'replace'
>>> ploneview.toLocalizedTime(None)
'Jul 22 2021'
```

This patch restores that behavior, checking the result before replacing the comma

@libargutxi @UnaiEtxaburu